### PR TITLE
Fixed path for types in clientside jsconfig.json

### DIFF
--- a/client_packages/jsconfig.json
+++ b/client_packages/jsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../jsconfig.base.json",
 	"compilerOptions": {
-		"types": ["../node_modules/@ragempcommunity/types-server", "./@types"]
+		"types": ["../node_modules/@ragempcommunity/types-client", "./@types"]
 	}
 }


### PR DESCRIPTION
Path was pointing towards server types instead of client